### PR TITLE
Add throws to SelfOrganizingListMap.remove to match JavaDoc

### DIFF
--- a/src/main/java/ee/ut/cs/aa/grading/selfOrganizing/SelfOrganizingListMap.java
+++ b/src/main/java/ee/ut/cs/aa/grading/selfOrganizing/SelfOrganizingListMap.java
@@ -34,7 +34,7 @@ public interface SelfOrganizingListMap<Key, Value> {
      * @param key
      * @return Removed value.
      */
-    Value remove(Key key);
+    Value remove(Key key) throws NoSuchElementException;
 
 
     /**


### PR DESCRIPTION
Minor semantics change, does not affect any actual behavior because `NoSuchElementException extends RuntimeException`.
